### PR TITLE
Bug fix: Negative edge sampling

### DIFF
--- a/libs/linkpred/linkpred/LinkPredictionDataset.py
+++ b/libs/linkpred/linkpred/LinkPredictionDataset.py
@@ -2,7 +2,7 @@
 # @Author: Sadamori Kojaku
 # @Date:   2023-03-27 16:40:11
 # @Last Modified by:   Sadamori Kojaku
-# @Last Modified time: 2023-03-27 18:16:17
+# @Last Modified time: 2023-04-02 05:16:43
 # %%
 import numpy as np
 import pandas as pd
@@ -111,10 +111,7 @@ class LinkPredictionDataset:
         while n_sampled < n_test_edges:
 
             # Sample negative edges based on SBM sampler
-            _neg_src = np.random.choice(
-                src, size=n_test_edges - n_sampled, replace=True
-            )
-            _neg_trg = neg_edge_sampler.sampling(_neg_src, _neg_src, n_nodes + 1)
+            _neg_src, _neg_trg = neg_edge_sampler.sampling(n_test_edges - n_sampled)
 
             #
             # The sampled node pairs contain self loops, positive edges, and duplicates, which we remove here

--- a/libs/linkpred/linkpred/node_samplers.py
+++ b/libs/linkpred/linkpred/node_samplers.py
@@ -2,7 +2,7 @@
 # @Author: Sadamori Kojaku
 # @Date:   2023-01-16 17:34:35
 # @Last Modified by:   Sadamori Kojaku
-# @Last Modified time: 2023-01-17 03:32:22
+# @Last Modified time: 2023-04-02 05:16:05
 
 """Graph module to store a network and generate random walks from it."""
 import numpy as np
@@ -102,12 +102,16 @@ class SBMNodeSampler(NodeSampler):
         self.block2node.data = _csr_row_cumsum(
             self.block2node.indptr, self.block2node.data
         )
+        self.p0 = np.maximum(indeg, 1) / np.sum(np.maximum(indeg, 1))
         return self
 
-    def sampling(self, center_nodes, context_nodes, padding_id):
+    def sampling(self, size):
+        center_nodes = np.random.choice(
+            self.n_nodes, size=size, p=self.p0, replace=True
+        )
         block_ids = csr_sampling(self.group_membership[center_nodes], self.block2block)
-        context = csr_sampling(block_ids, self.block2node)
-        return context.astype(np.int64)
+        context_nodes = csr_sampling(block_ids, self.block2node)
+        return center_nodes.astype(np.int64), context_nodes.astype(np.int64)
 
 
 class ConfigModelNodeSampler(SBMNodeSampler):


### PR DESCRIPTION
Just found a bug in the negative edge sampling (sampling of unconnected node pairs) and fixed it. 

The "uniform" sampling is supposed to sample every pair of nodes (i,j) with an equal probability. However, this bug introduces a bias since it samples one of the node with prob. proportional to the degree, and the other node with a uniform sampling. 

I'm recalculating the results. 