### PR TITLE
adding class graphsage

### DIFF
--- a/libs/embcom/embcom/embeddings.py
+++ b/libs/embcom/embcom/embeddings.py
@@ -13,6 +13,12 @@ from sklearn.decomposition import TruncatedSVD
 
 from embcom import rsvd, samplers, utils
 
+import stellargraph
+from tensorflow import keras
+from stellargraph.data import UnsupervisedSampler
+from stellargraph.mapper import GraphSAGELinkGenerator, GraphSAGENodeGenerator
+from stellargraph.layer import GraphSAGE, link_classification
+
 try:
     import glove
 except ImportError:
@@ -480,3 +486,124 @@ class DegreeEmbedding:
         emb = np.zeros((len(self.degree), dim))
         emb[:, 0] = self.degree
         return emb
+
+
+class graphSAGE:
+    """A python class for the GraphSAGE.
+    Parameters
+    ----------
+    num_walks : int (optional, default 1)
+        Number of walks per node
+    walk_length : int (optional, default 5)
+        Length of walks
+    """
+
+    def __init__(
+        self,
+        num_walks=1,
+        walk_length=5,
+        dim=10,
+        layer_sizes = [50, 10],
+        num_samples = [10,5],
+        batch_size=50,
+        epochs = 4,
+        verbose=False,
+    ):
+        self.in_vec = None  # In-vector
+        self.out_vec = None  # Out-vector
+        self.feature_vector = None
+        self.model = None
+        self.generator = None
+        self.train_gen = None
+        self.G = None
+        
+        self.num_walks = num_walks
+        self.walk_length = walk_length
+        self.layer_sizes = layer_sizes
+        self.num_samples = num_samples
+        self.batch_size = batch_size
+        self.epochs = 4
+        
+        self.verbose = verbose
+
+        
+    def fit(self, net):
+        """Takes a network as an input, transforms it into an adjacency matrix, and generates 
+        feature vectors for nodes and creates a StellarGraph object"""
+
+        # transform into an adjacency matrix
+        A = utils.to_adjacency_matrix(net)
+
+        # create node features
+        self.create_feature_vector(A, feature_dim=50)
+
+        # transform the adjacency matrix into a networkx Graph object
+        self.G = nx.Graph(A)
+        nodes = [*self.G.nodes()]
+
+        # transform it into a StellarGraph
+        self.G = stellargraph.StellarGraph.from_networkx(graph=self.G, node_features=zip(nodes,self.feature_vector))
+        
+        # Create the UnsupervisedSampler instance with the relevant parameters passed to it
+        unsupervised_samples = UnsupervisedSampler(self.G, 
+                                                   nodes=nodes, 
+                                                   length=self.walk_length, 
+                                                   number_of_walks=self.num_walks)
+
+        self.generator = GraphSAGELinkGenerator(self.G, self.batch_size, self.num_samples)
+        self.train_gen = self.generator.flow(unsupervised_samples)
+        
+        return self
+    
+    def create_feature_vector(self, A, feature_dim=50):
+        """Takes an adjacency matrix and generates feature vectors using 
+        Laplacian Eigen Map"""
+
+        lapeigen = embcom.LaplacianEigenMap(p=100, q=40)
+        lapeigen.fit(A)
+        self.feature_vector = lapeigen.transform(feature_dim, return_out_vector=False)
+        
+        return self
+
+    def train_GraphSAGE(self):
+        graphsage = GraphSAGE(
+            layer_sizes=self.layer_sizes, generator=self.generator, bias=True, dropout=0.0, normalize="l2"
+        )
+
+        self.in_vec, self.out_vec = graphsage.in_out_tensors()
+        
+
+        prediction = link_classification(
+            output_dim=1, output_act="sigmoid", edge_embedding_method="ip"
+        )(self.out_vec)
+
+
+        self.model = keras.Model(inputs=self.in_vec, outputs=prediction)
+
+        self.model.compile(
+            optimizer=keras.optimizers.Adam(lr=1e-3),
+            loss=keras.losses.binary_crossentropy,
+            metrics=[keras.metrics.binary_accuracy],
+        )
+
+        history = self.model.fit(
+                            self.train_gen,
+                            epochs=self.epochs,
+                            verbose=self.verbose,
+                            use_multiprocessing=False,
+                            workers=4,
+                            shuffle=True,
+                    )
+
+    def get_embeddings(self):
+
+        x_inp_src = self.in_vec[0::2]
+        x_out_src = self.out_vec[0]
+        embedding_model = keras.Model(inputs=x_inp_src, outputs=x_out_src)
+
+        node_ids = [*self.G.nodes()]
+        node_gen = GraphSAGENodeGenerator(self.G, self.batch_size, self.num_samples).flow(node_ids)
+
+        node_embeddings = embedding_model.predict(node_gen, workers=4, verbose=0)
+
+        return node_embeddings

--- a/workflow/EmbeddingModels.py
+++ b/workflow/EmbeddingModels.py
@@ -42,3 +42,10 @@ def modspec(network, dim):
 #    model = embcom.embeddings.NonBacktrackingSpectralEmbedding()
 #    model.fit(network)
 #    return model.transform(dim=dim)
+
+@embedding_model
+def graphsage(network, num_walks=1, walk_length=5, dim=10):
+    model = embcom.embeddings.graphSAGE(num_walks=num_walks, walk_length=walk_length, dim=dim)
+    model.fit(network)
+    model.train_GraphSAGE()
+    return model.get_embeddings()


### PR DESCRIPTION
Even though the name suggests GCN, it is actually the implementation of GraphSAGE. I wanted to make the codes look like the ones in the workflow, but there are differences.

As @skojaku suggested, I employed LaplacianEigenMap() method to create feature vectors for nodes and create_feature_vectors() method takes care of this. Next, since GraphSAGE needed me to transform the adjacency matrix into a StellarGraph object, graphSAGE.fit() method transforms the adjacency matrix by using the feature vector as well.

My workflow continues with training of the model with train_GraphSAGE() method. Here, based on the number of walks and walk length, it takes more and more time indeed. self.model.fit() method takes a parameter use_multiprocessing, which we might have to use (or, I can discover using directly the GPU option).

Last method get_embeddings() is the one that passing the nodes from the model and producing the embeddings.