### PR TITLE
Specifying the data folder with config.yaml

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -9,13 +9,14 @@ from workflow.NetworkTopologyPredictionModels import *
 
 include: "./workflow/workflow_utils.smk"  # not able to merge this with snakemake_utils.py due to some path breakage issues
 
+configfile: "workflow/config.yaml"
 
 # ====================
 # Root folder path setting
 # ====================
 
 # network file
-DATA_DIR = "data"  # set test_data for testing
+DATA_DIR = config["data_dir"]  # set test_data for testing
 
 DERIVED_DIR = j(DATA_DIR, "derived")
 NETWORK_DIR = j(DERIVED_DIR, "networks")
@@ -32,8 +33,9 @@ DATA_LIST = [
 
 # Small networks
 # Comment out if you want to run for all networks
-with open("workflow/small-networks.json", "r") as f:
-    DATA_LIST = json.load(f)
+if config["small_networks"]:
+    with open("workflow/small-networks.json", "r") as f:
+        DATA_LIST = json.load(f)
 
 N_ITERATION = 5
 

--- a/workflow/config.template.yaml
+++ b/workflow/config.template.yaml
@@ -1,3 +1,4 @@
-# set the directories below and copy this file as `config.yaml`
-data_dir: "./data/"
+# set the directories below and copy this file as `workflow/config.yaml`
+data_dir: "data/"
 paper_dir: "./paper/current/"
+small_networks: False 


### PR DESCRIPTION
With this PR, you now have the option to select your desired data folder path. This setting is no longer in Snakemake, but has been moved to the "workflow/config.yaml" file. Additionally, you  can also choose whether to run the Snakemake for small networks or all networks in the same config.yaml file.

To aid in this transition, a template file, "workflow/config.template.yaml" has been created, so that you can easily keep the original settings.